### PR TITLE
chore(workflows): add pull request workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,9 @@
+name: Pull Request
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  rust-checks:
+    uses: paastech-cloud/.github/.github/workflows/rust-ci.yml@main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   rust-checks:
-    uses: paastech-cloud/.github/.github/workflows/rust-ci.yml@main
+    uses: paastech-cloud/.github/.github/workflows/rust-ci.yml@059bd0ba8bb24461bafa6e58b4dce3713732b73d

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   rust-checks:
-    uses: paastech-cloud/.github/.github/workflows/rust-ci.yml@059bd0ba8bb24461bafa6e58b4dce3713732b73d
+    uses: paastech-cloud/.github/.github/workflows/rust-ci.yml@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "git-auth-layer",

--- a/git-repo-manager/src/service.rs
+++ b/git-repo-manager/src/service.rs
@@ -32,17 +32,17 @@ impl GitRepoManager for GitRepoManagerService {
         );
 
         // Check if the repository already exists, if it does return error otherwise continue
-        if let Ok(_) = fs::metadata(new_repo_path.clone()) {
+        if fs::metadata(new_repo_path.clone()).is_ok() {
             return Err(Status::already_exists(format!(
                 "repository {} already exists",
-                new_repo_path.clone(),
+                new_repo_path,
             )));
         }
 
         // Initialize empty git repository if it fails rollback and return error otherwise continue
         if Command::new("sh")
             .arg("-c")
-            .arg(format!("git init --bare {}", new_repo_path.clone()))
+            .arg(format!("git init --bare {}", new_repo_path))
             .output()
             .is_err()
         {
@@ -50,7 +50,7 @@ impl GitRepoManager for GitRepoManagerService {
         }
 
         let reply = RepositoryResponse {
-            message: format!("Created repository {}", request_data.repository_path).to_owned(),
+            message: format!("Created repository {}", request_data.repository_path),
         };
 
         Ok(Response::new(reply))
@@ -68,11 +68,11 @@ impl GitRepoManager for GitRepoManagerService {
             request_data.repository_path
         );
 
-        if let Err(_) = fs::metadata(full_repo_path.clone()) {
+        if fs::metadata(full_repo_path.clone()).is_err() {
             return Err(Status::not_found(""));
         }
 
-        if let Err(_) = fs::remove_dir_all(full_repo_path) {
+        if fs::remove_dir_all(full_repo_path).is_err() {
             return Err(Status::unknown("Failed removing repository"));
         }
 


### PR DESCRIPTION
# What does this do ?
Add a workflow that runs callable workflow `rust-ci.yaml` on `paastech-cloud/.github` repository. It is triggered by pull requests. [see](https://github.com/paastech-cloud/.github/blob/059bd0ba8bb24461bafa6e58b4dce3713732b73d/.github/workflows/rust-ci.yml)
This also fixes any issues with the code that the PR detected.

# Why ?
It aims to avoid having the reviewer check code that isn't clean, which saves time.

# How do I test it ?
Just look at the run triggered by that PR, look at the action tabs or trigger it manually.