### PR TITLE
make(auth-layer): externalize config and logs, rootless dockerfile

### DIFF
--- a/git-auth-layer/.gitignore
+++ b/git-auth-layer/.gitignore
@@ -1,1 +1,3 @@
 scripts/output/
+logs/
+etc/

--- a/git-auth-layer/Dockerfile.server
+++ b/git-auth-layer/Dockerfile.server
@@ -50,4 +50,4 @@ COPY --from=build --chown=git:git /app/target/release/git-auth-layer /usr/bin
 
 EXPOSE 22
 
-CMD ["/usr/sbin/sshd", "-D"]
+CMD ["/usr/sbin/sshd", "-D", "-E", "/proc/1/fd/1", "-o", "LogLevel=VERBOSE"]

--- a/git-auth-layer/Dockerfile.server
+++ b/git-auth-layer/Dockerfile.server
@@ -29,6 +29,9 @@ RUN adduser --disabled-password git && \
 # add authorized_keys file
 COPY --chown=git:git ./scripts/output/server/authorized_keys /home/git/.ssh/authorized_keys
 
+# add config file
+COPY --chown=git:git ./config/config.env /etc/paastech/git-auth-layer/config.env
+
 # add adequare rights to authorized_keys file see https://man.openbsd.org/sshd.8#FILES
 RUN chmod 600 /home/git/.ssh/authorized_keys
 
@@ -40,14 +43,20 @@ RUN mkdir -p /srv && \
 
 RUN mkdir -p /var/run/sshd
 
-# initialize log directory and config file
-COPY --chown=git:git ./config/config.env /etc/paastech/git-auth-layer/config.env
-
 RUN mkdir -p /var/log/paastech/git-auth-layer && chown -R git:git /var/log/paastech/git-auth-layer
 
 # copy built binary
 COPY --from=build --chown=git:git /app/target/release/git-auth-layer /usr/bin
 
-EXPOSE 22
+# tedious steps to make git accessible for the git user
+RUN mkdir /opt/ssh && mv /etc/ssh/ssh*key /opt/ssh
 
-CMD ["/usr/sbin/sshd", "-D", "-E", "/proc/1/fd/1", "-o", "LogLevel=VERBOSE"]
+RUN chown -R git:git /opt/ssh
+
+COPY --chown=git:git config/sshd_config /opt/ssh
+
+USER git
+
+EXPOSE 2022
+
+CMD ["/usr/sbin/sshd", "-D", "-E", "/proc/1/fd/1", "-o", "LogLevel=VERBOSE", "-f", "/opt/ssh/sshd_config"]

--- a/git-auth-layer/Dockerfile.server
+++ b/git-auth-layer/Dockerfile.server
@@ -18,7 +18,8 @@ FROM debian:bookworm-slim
 # install requirements
 RUN apt-get update && apt-get install -y \
     git \
-    openssh-server
+    openssh-server \
+    net-tools
 
 # add git user
 RUN adduser --disabled-password git && \
@@ -26,24 +27,14 @@ RUN adduser --disabled-password git && \
     chown -R git:git /home/git/.ssh && \
     chmod 700 /home/git/.ssh
 
-# add authorized_keys file
-COPY --chown=git:git ./scripts/output/server/authorized_keys /home/git/.ssh/authorized_keys
-
-# add config file
-COPY --chown=git:git ./config/config.env /etc/paastech/git-auth-layer/config.env
-
-# add adequare rights to authorized_keys file see https://man.openbsd.org/sshd.8#FILES
-RUN chmod 600 /home/git/.ssh/authorized_keys
-
 # initialize repositories
 RUN mkdir -p /srv && \
     git init --bare /srv/210e364a-3a07-43ba-85b8-2e1c646bd39a.git && \
     git init --bare /srv/4773ddcb-a600-49be-ad63-b769a1ad1eec.git && \
     chown -R git:git /srv
 
+# mandatory for sshd
 RUN mkdir -p /var/run/sshd
-
-RUN mkdir -p /var/log/paastech/git-auth-layer && chown -R git:git /var/log/paastech/git-auth-layer
 
 # copy built binary
 COPY --from=build --chown=git:git /app/target/release/git-auth-layer /usr/bin

--- a/git-auth-layer/compose.yml
+++ b/git-auth-layer/compose.yml
@@ -3,6 +3,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.server
+    volumes:
+      - "./scripts/output/server:/home/git/.ssh"
+      - "./config:/etc/paastech/git-auth-layer"
+      - "./logs:/var/log/paastech/git-auth-layer"
 
   client-a:
     build:

--- a/git-auth-layer/config/sshd_config
+++ b/git-auth-layer/config/sshd_config
@@ -1,0 +1,18 @@
+## Use a non-privileged port
+Port 2022
+## provide the new path containing these host keys
+HostKey /opt/ssh/ssh_host_rsa_key
+HostKey /opt/ssh/ssh_host_ecdsa_key
+HostKey /opt/ssh/ssh_host_ed25519_key
+## Enable DEBUG log. You can ignore this but this may help you debug any issue while enabling SSHD for the first time
+LogLevel DEBUG3
+ChallengeResponseAuthentication no
+UsePAM yes
+X11Forwarding yes
+PrintMotd no
+## Provide a path to store PID file which is accessible by normal user for write purpose
+PidFile /opt/ssh/sshd.pid
+AcceptEnv LANG LC_*
+## Accept env
+Subsystem       sftp    /usr/lib/openssh/sftp-server
+PermitUserEnvironment yes

--- a/git-auth-layer/scripts/init-dev-env.sh
+++ b/git-auth-layer/scripts/init-dev-env.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 
-rm -rf scripts/output/client* scripts/server
+rm -rf scripts/output/client* scripts/server logs etc
 
 mkdir -p scripts/output/client-a scripts/output/client-b scripts/output/server
+
+mkdir -p logs
+
+mkdir -p etc/ssh
+
+ssh-keygen -A -f $(pwd)
 
 ssh-keygen -t ed25519 -C "userA@user.fr" -f scripts/output/client-a/id_ed25519 -q -N ""
 

--- a/git-auth-layer/src/main.rs
+++ b/git-auth-layer/src/main.rs
@@ -34,10 +34,12 @@ async fn main() {
     });
 
     // Extract ssh command from environment
-    let ssh_command = env::var(SSH_ORIGINAL_COMMAND_KEY).unwrap_or_else(|_| {
-        log::error!("Client did not use git cli correctly");
-        exit(1);
-    });
+    let ssh_command = env::var(SSH_ORIGINAL_COMMAND_KEY)
+        .unwrap_or_else(|_| {
+            log::error!("Client did not use git cli correctly");
+            exit(1);
+        })
+        .replace('/', "");
 
     if !is_command_valid(&ssh_command) {
         log::error!("Client executed an invalid command");


### PR DESCRIPTION
## What does this PR do ?

Since it has been determined that the git server can be containerized, the dockerfile needs to be closer to prod ready :
- made it rootless,
- externalized config and logs

The compose file was then modified to use volumes for more transparent development.

Scripts were also improved to adapt for that configuration.

### How should this be manually tested ?

Refer to the README in git-auth-layer directory

## Other changes

Since the port isn't 22, the new git remote becomes something like

```
git@server:2022/uuid.git
```

Which is an issue because the trailing slash remains. Hence, it was removed here : e8cb025343dd35d5c3a6de4ebf10f327f6baae62

