### PR TITLE
make(dockerfile): remove proto user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,6 @@ FROM debian:bookworm-slim
 
 WORKDIR /app
 
-# add proto user
-RUN useradd proto
-
-COPY --from=build --chown=proto:proto /app/target/release/server /app
-
-USER proto
+COPY --from=build /app/target/release/server /app
 
 CMD [ "./server" ]


### PR DESCRIPTION
## What does this PR do ?

This PR removes the proto user from the image.

Since this container will share a volume with the git-ssh-server, they need to have the same user, which is tedious to configure on the host machine. For simplicity's sake, they will just be both root to avoid permissions issues.

### How should this be manually tested ?

Just build it and run it according to the .env.template file